### PR TITLE
Fix version conflicts caused by PR#26

### DIFF
--- a/tests/e2e/E2eTests.csproj
+++ b/tests/e2e/E2eTests.csproj
@@ -21,8 +21,8 @@
 
   <ItemGroup>
     <PackageReference Include="Autodesk.Forge.Core.E2eTestHelpers" Version="1.*" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump Microsoft.NET.Test.Sdk from 15.9.0 to 16.10.0. [(PR#26)](https://github.com/zhuliice/forge-api-dotnet-design.automation/pull/26).
Hope this fix can help you.

Best regards,
sucrose